### PR TITLE
TASK: Remove special handling of `content` attribute in html-tags

### DIFF
--- a/Classes/Service/AfxService.php
+++ b/Classes/Service/AfxService.php
@@ -113,31 +113,20 @@ class AfxService
     {
         $tagName = $payload['identifier'];
 
-        $attributePrefix = null;
-        $attributePrefixExceptions = [];
-
         // Tag
         if (strpos($tagName, ':') !== false) {
             // Named fusion-object
             $fusion = $tagName . ' {' . PHP_EOL;
+            // Attributes are not prefixed
+            $attributePrefix = '';
         } else {
             // Neos.Fusion:Tag
             $fusion = 'Neos.Fusion:Tag {' . PHP_EOL;
             $fusion .= $indentation . self::INDENTATION .'tagName = \'' .  $tagName . '\'' . PHP_EOL;
-
+            // Attributes are rendered as tag-attributes
             $attributePrefix = 'attributes.';
-            $attributePrefixExceptions = ['content'];
-
-            $hasContent = false;
-            if ($payload['props'] && count($payload['props']) > 0) {
-                foreach ($payload['props'] as $propName => $prop) {
-                    if ($propName == 'content') {
-                        $hasContent = true;
-                    }
-                }
-            }
-
-            if ($payload['selfClosing'] === true && $hasContent === false) {
+            // Self closing Tags stay self closing
+            if ($payload['selfClosing'] === true) {
                 $fusion .= $indentation . self::INDENTATION .'selfClosingTag = true' . PHP_EOL;
             }
         }
@@ -150,10 +139,8 @@ class AfxService
                 } else {
                     if ($propName{0} === '@') {
                         $fusionName = $propName;
-                    } elseif ($attributePrefix && !in_array($propName, $attributePrefixExceptions)) {
-                        $fusionName = $attributePrefix . $propName;
                     } else {
-                        $fusionName = $propName;
+                        $fusionName = $attributePrefix . $propName;
                     }
                     $propFusion =  self::astToFusion($prop, $indentation . self::INDENTATION);
                     if ($propFusion !== null) {

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ All whitepaces around the outer elements are ignored. Whitepaces that are connec
 
 ### HTML-Tags (Tags without Namespace)
 
-HTML-Tags are converted to `Neos.Fusion:Tag` Objects. All attributes except `content` are rendered as attributes and the content/children are directly rendered as property-names. All other attributes are rendered as tag-attributes.
+HTML-Tags are converted to `Neos.Fusion:Tag` Objects. All attributes of the afx-tag are rendered as tag-attributes.
  
 The following html: 
 ```

--- a/Tests/Functional/AfxServiceTest.php
+++ b/Tests/Functional/AfxServiceTest.php
@@ -167,7 +167,8 @@ EOF;
         $expectedFusion = <<<'EOF'
 Neos.Fusion:Tag {
     tagName = 'h1'
-    content = 'bar'
+    selfClosingTag = true
+    attributes.content = 'bar'
     attributes.class = 'fooo'
 }
 EOF;


### PR DESCRIPTION
The special rule for-content attributes in html-tags is removed. The only supported way to define content of html-tags
is creating children that can be a single expression or a list of nodes or expressions.

Background. The special handling of the `content`-attributes always was was a bit strange and since the latest changes
allow child-content to be defined as a single expression instead of an array aswell it is
no longer needed.