### PR TITLE
!!! TASK: Render keys of children as string `item_x` starting with `x=1` instead of pure numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/vendor
+/Packages
+/composer.lock

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,0 +1,1 @@
+preset: psr2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: php
+php:
+  - '7.0'
+  - '7.1'
+script: composer test

--- a/Classes/Exception/AfxException.php
+++ b/Classes/Exception/AfxException.php
@@ -3,5 +3,4 @@ namespace PackageFactory\AtomicFusion\AFX\Exception;
 
 class AfxException extends \Exception
 {
-
 }

--- a/Classes/Service/AfxService.php
+++ b/Classes/Service/AfxService.php
@@ -13,7 +13,6 @@ use PackageFactory\AtomicFusion\AFX\Exception\AfxException;
  */
 class AfxService
 {
-
     const INDENTATION = '    ';
 
     /**

--- a/Classes/Service/AfxService.php
+++ b/Classes/Service/AfxService.php
@@ -202,7 +202,7 @@ class AfxService
             $fusion = 'Neos.Fusion:Array {' . PHP_EOL;
             foreach ($payload as $astNode) {
                 // detect key
-                $fusionName = $index;
+                $fusionName = 'item_' . $index;
                 if ($keyProperty = Arrays::getValueByPath($astNode, 'payload.props.@key')) {
                     if ($keyProperty['type'] == 'string') {
                         $fusionName = $keyProperty['payload'];

--- a/README.md
+++ b/README.md
@@ -157,15 +157,15 @@ Is transpiled as:
 Neos.Fusion:Tag {
     tagName = 'h1'
     content = Neos.Fusion:Array {
-        1 = {props.title}
-        2 = ': '
-        3 = ${props.subtitle}
+        item_1 = {props.title}
+        item_2 = ': '
+        item_3 = ${props.subtitle}
     }
 }
 ```
 
 The `@key`-property of tag-children inside alters the name of the fusion-attribute to recive render the array-child into. 
-If no `@key`-property is given the numerical index starting with 1 is used.
+If no `@key`-property is given the string 'index_x' starting by 1 is used.
 
 ```
 <Vendor.Site:Prototype @children="text">
@@ -221,8 +221,8 @@ Is transpiled as:
 Neos.Fusion:Tag {
 	tagName = 'h1'
 	contents = Neos.Fusion:Array {
-		1 = ${'eelExpression 1'}
-		2 = ${'eelExpression 2'}   
+		item_1 = ${'eelExpression 1'}
+		item_2 = ${'eelExpression 2'}   
 	}
 }
 ```
@@ -239,9 +239,9 @@ Is transpiled as:
 Neos.Fusion:Tag {
 	tagName = 'h1'
 	contents = Neos.Fusion:Array {
-		1 = ${'eelExpression 1'}
-		2 = ' '
-		3 = ${'eelExpression 2'}   
+		item_1 = ${'eelExpression 1'}
+		item_2 = ' '
+		item_3 = ${'eelExpression 2'}   
 	}
 }
 ```

--- a/Tests/Functional/AfxServiceTest.php
+++ b/Tests/Functional/AfxServiceTest.php
@@ -85,13 +85,13 @@ EOF;
         $afxCode = '<h1></h1><p></p><p></p>';
         $expectedFusion = <<<'EOF'
 Neos.Fusion:Array {
-    1 = Neos.Fusion:Tag {
+    item_1 = Neos.Fusion:Tag {
         tagName = 'h1'
     }
-    2 = Neos.Fusion:Tag {
+    item_2 = Neos.Fusion:Tag {
         tagName = 'p'
     }
-    3 = Neos.Fusion:Tag {
+    item_3 = Neos.Fusion:Tag {
         tagName = 'p'
     }
 }
@@ -107,15 +107,15 @@ EOF;
         $afxCode = 'Foo<h1></h1>Bar<p></p>Baz';
         $expectedFusion = <<<'EOF'
 Neos.Fusion:Array {
-    1 = 'Foo'
-    2 = Neos.Fusion:Tag {
+    item_1 = 'Foo'
+    item_2 = Neos.Fusion:Tag {
         tagName = 'h1'
     }
-    3 = 'Bar'
-    4 = Neos.Fusion:Tag {
+    item_3 = 'Bar'
+    item_4 = Neos.Fusion:Tag {
         tagName = 'p'
     }
-    5 = 'Baz'
+    item_5 = 'Baz'
 }
 EOF;
         $this->assertEquals($expectedFusion, AfxService::convertAfxToFusion($afxCode));
@@ -129,10 +129,10 @@ EOF;
         $afxCode = '  <h1></h1><p></p>  ';
         $expectedFusion = <<<'EOF'
 Neos.Fusion:Array {
-    1 = Neos.Fusion:Tag {
+    item_1 = Neos.Fusion:Tag {
         tagName = 'h1'
     }
-    2 = Neos.Fusion:Tag {
+    item_2 = Neos.Fusion:Tag {
         tagName = 'p'
     }
 }
@@ -147,13 +147,13 @@ EOF;
         $afxCode = '<h1></h1><p></p><p></p>';
         $expectedFusion = <<<'EOF'
 Neos.Fusion:Array {
-    1 = Neos.Fusion:Tag {
+    item_1 = Neos.Fusion:Tag {
         tagName = 'h1'
     }
-    2 = Neos.Fusion:Tag {
+    item_2 = Neos.Fusion:Tag {
         tagName = 'p'
     }
-    3 = Neos.Fusion:Tag {
+    item_3 = Neos.Fusion:Tag {
         tagName = 'p'
     }
 }
@@ -351,11 +351,11 @@ EOF;
 Neos.Fusion:Tag {
     tagName = 'h1'
     content = Neos.Fusion:Array {
-        1 = Neos.Fusion:Tag {
+        item_1 = Neos.Fusion:Tag {
             tagName = 'strong'
             content = 'foo'
         }
-        2 = Neos.Fusion:Tag {
+        item_2 = Neos.Fusion:Tag {
             tagName = 'i'
             content = 'bar'
         }
@@ -384,11 +384,11 @@ EOF;
 Neos.Fusion:Tag {
     tagName = 'h1'
     content = Neos.Fusion:Array {
-        1 = Neos.Fusion:Tag {
+        item_1 = Neos.Fusion:Tag {
             tagName = 'strong'
             content = 'foo'
         }
-        2 = Neos.Fusion:Tag {
+        item_2 = Neos.Fusion:Tag {
             tagName = 'i'
             content = 'bar'
         }
@@ -432,12 +432,12 @@ EOF;
 Neos.Fusion:Tag {
     tagName = 'h1'
     content = Neos.Fusion:Array {
-        1 = 'a string'
-        2 = Neos.Fusion:Tag {
+        item_1 = 'a string'
+        item_2 = Neos.Fusion:Tag {
             tagName = 'strong'
             content = 'a tag'
         }
-        3 = ${eelExpression()}
+        item_3 = ${eelExpression()}
     }
 }
 EOF;
@@ -459,9 +459,9 @@ EOF;
 Neos.Fusion:Tag {
     tagName = 'h1'
     content = Neos.Fusion:Array {
-        1 = ${eelExpression1}
-        2 = ${eelExpression2}
-        3 = ${eelExpression3}
+        item_1 = ${eelExpression1}
+        item_2 = ${eelExpression2}
+        item_3 = ${eelExpression3}
     }
 }
 EOF;
@@ -481,9 +481,9 @@ EOF;
 Neos.Fusion:Tag {
     tagName = 'h1'
     content = Neos.Fusion:Array {
-        1 = ${eelExpression1}
-        2 = ' '
-        3 = ${eelExpression2}
+        item_1 = ${eelExpression1}
+        item_2 = ' '
+        item_3 = ${eelExpression2}
     }
 }
 EOF;
@@ -503,9 +503,9 @@ EOF;
 Neos.Fusion:Tag {
     tagName = 'h1'
     content = Neos.Fusion:Array {
-        1 = 'String '
-        2 = ${eelExpression}
-        3 = ' String'
+        item_1 = 'String '
+        item_2 = ${eelExpression}
+        item_3 = ' String'
     }
 }
 EOF;
@@ -514,7 +514,7 @@ EOF;
 
     /**
      * @test
-     * @expectedException \Neos\Fusion\Exception
+     * @expectedException \PackageFactory\Afx\Exception
      */
     public function unclosedTagsRaisesException()
     {
@@ -524,7 +524,7 @@ EOF;
 
     /**
      * @test
-     * @expectedException \Neos\Fusion\Exception
+     * @expectedException \PackageFactory\Afx\Exception
      */
     public function unclosedAttributeRaisesException()
     {
@@ -534,7 +534,7 @@ EOF;
 
     /**
      * @test
-     * @expectedException \Neos\Fusion\Exception
+     * @expectedException \PackageFactory\Afx\Exception
      */
     public function unclosedExpressionRaisesException()
     {

--- a/Tests/Functional/AfxServiceTest.php
+++ b/Tests/Functional/AfxServiceTest.php
@@ -1,10 +1,11 @@
 <?php
 namespace PackageFactory\AtomicFusion\AFX\Tests\Functional;
 
-use Neos\Flow\Tests\FunctionalTestCase;
+use PHPUnit\Framework\TestCase;
 use PackageFactory\AtomicFusion\AFX\Service\AfxService;
+use PackageFactory\AtomicFusion\AFX\Exception;
 
-class AfxServiceTest extends FunctionalTestCase
+class AfxServiceTest extends TestCase
 {
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,31 @@
         "neos/fusion": "^3.2.0 || dev-master",
         "packagefactory/afx": "~2.0.1"
     },
+    "require-dev": {
+      "phpunit/phpunit": "~4.8 || ~5.4.0"
+    },
     "autoload": {
         "psr-4": {
             "PackageFactory\\AtomicFusion\\AFX\\": "Classes/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+          "PackageFactory\\AtomicFusion\\AFX\\Tests\\": "Tests/"
         }
     },
     "extra": {
         "neos": {
             "package-key": "PackageFactory.AtomicFusion.AFX"
         }
+    },
+    "scripts": {
+      "test:functional": [
+        "composer install",
+        "vendor/bin/phpunit Tests/Functional"
+      ],
+      "test": [
+        "composer test:functional"
+      ]
     }
 }


### PR DESCRIPTION
That way defining also children with @key will be rendered in the original order.